### PR TITLE
Pywin32-224 TerminateProcess Function Moved

### DIFF
--- a/wexpect.py
+++ b/wexpect.py
@@ -2114,7 +2114,7 @@ class Wtty:
     def terminate_child(self):
         """Terminate the child process."""
         
-        win32api.win32process.TerminateProcess(self.__childProcess, 1)
+        win32api.TerminateProcess(self.__childProcess, 1)
         
     def createKeyEvent(self, char):
         """Creates a single key record corrosponding to


### PR DESCRIPTION
In version 224 of pywin32, the function `TerminateProcess()` is no longer located in 
`win32api.win32process ` so you will get a `win32api does not contain module win32process` error.
`TerminateProcess()` is now located under `win32api` and called like `win32api.TerminateProcess()`

I opened up this issue, https://github.com/raczben/wexpect/issues/4#issue-468194458
Here is a screenshot of the pywin32-224 documentation.
<img width="559" alt="pywin32Doc" src="https://user-images.githubusercontent.com/45643710/61230481-1a9b5b00-a6f8-11e9-930f-d2d919330fd6.PNG">
