### PR TITLE
Add install dependencies to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,11 @@ classifier =
 keywords =
     scripting, automation, expect, pexpect, wexpect
 
+[options]
+install_requires =
+    pywin32 >= 220;platform_system=='Windows'
+    psutil >= 5.0.0
+
 [options.extras_require]
 test =
     coverage


### PR DESCRIPTION
If these dependencies are not declared in setup.cfg, they won't be
installed when installing the wheel for wexpect. As they are obviously
required for running wexpect, they should also be declared as runtime
dependency and thus also be installed alongside wexpect.
